### PR TITLE
文字コードの指定間違いを修正

### DIFF
--- a/client/components/meta/index.tsx
+++ b/client/components/meta/index.tsx
@@ -13,7 +13,7 @@ export const Meta = ({ title, description, keyword, image, url }: Props) => {
     <Head>
       <title>{title}</title>
       <meta property="og:title" content={title} />
-      <meta content="text/html; charset=shift_jis" httpEquiv="Content-Type" />
+      <meta content="text/html; charset=utf-8" httpEquiv="Content-Type" />
       <meta
         property="og:description"
         content={


### PR DESCRIPTION
そもそも、この行自体が不要な気もします。(ページ全体のソースを見た時に、`<meta charset="utf-8">` が出力されているのを確認しました。)